### PR TITLE
switch to the worked GoCD version 19.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ project.ext.versions = [
 gocdPlugin {
   id = 'com.thoughtworks.gocd.elastic-agent.azure'
   pluginVersion = '1.0.0'
-  goCdVersion = '19.4.0'
+  goCdVersion = '19.2.0'
   name = 'GoCD Elastic Agent Plugin for Azure'
   description = 'GoCD Elastic Agent Plugin for Azure allows efficient usage of Azure instances'
   vendorName = 'ThoughtWorks, Inc.'

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/azure/AzureInstanceManager.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/azure/AzureInstanceManager.java
@@ -44,10 +44,11 @@ public class AzureInstanceManager {
     VmConfig config = buildVmConfig(request, settings, serverInfo);
     VirtualMachine virtualMachine = client.createVM(config);
     LOG.info("[Instance Manager] Created instance: {}", virtualMachine.name());
-    client.installGoAgent(config);
+    // client.installGoAgent(config);
     executeCustomScript(client, config);
-    client.startAgent(config);
-    LOG.info("[Instance Manager] Started go-agent on instance: {}", virtualMachine.name());
+    LOG.info("[Instance Manager] Executed custom script: {}", virtualMachine.name());
+    // client.startAgent(config);
+    // LOG.info("[Instance Manager] Started go-agent on instance: {}", virtualMachine.name());
     return mapper.map(virtualMachine);
   }
 

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/azure/Constants.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/azure/Constants.java
@@ -46,6 +46,6 @@ public interface Constants {
   String REQUEST_SERVER_INFO = REQUEST_SERVER_PREFIX + ".server-info.get";
   String REQUEST_ADD_SERVER_HEALTH_MESSAGES = REQUEST_SERVER_PREFIX + ".server-health.add-messages";
 
-  String SUPPORTED_GO_SERVER_VERSION= "19.4.0-9155";
+  String SUPPORTED_GO_SERVER_VERSION= "19.2.0-8641";
 
 }

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/azure/utils/Util.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/azure/utils/Util.java
@@ -31,8 +31,8 @@ import java.util.UUID;
 
 public class Util {
 
-  public static final String PLUGIN_VERSION_KEY = "pluginVersion";
-  public static final String PLUGIN_ID_KEY = "pluginId";
+  public static final String PLUGIN_VERSION_KEY = "version";
+  public static final String PLUGIN_ID_KEY = "id";
   private static Random random = new Random();
 
   public static String readResource(String resourceFile) {

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/azure/DownloadUrlsTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/azure/DownloadUrlsTest.java
@@ -24,12 +24,12 @@ class DownloadUrlsTest {
 
   @Test
   void testLinuxGoAgentDownloadUrlShouldFetchDefaultURLForVersionNotPublished() {
-    assertEquals("https://download.gocd.org/binaries/19.4.0-9155/generic/go-agent-19.4.0-9155.zip", DownloadUrls.linuxGoAgent("not valid"));
+    assertEquals("https://download.gocd.org/binaries/19.2.0-8641/generic/go-agent-19.2.0-8641.zip", DownloadUrls.linuxGoAgent("not valid"));
   }
 
   @Test
   void testWindowsGoAgentDownloadUrlShouldFetchDefaultURLForVersionNotPublished() {
-    assertEquals("https://download.gocd.org/binaries/19.4.0-9155/win/go-agent-19.4.0-9155-jre-64bit-setup.exe", DownloadUrls.windowsGoAgent("19.xyz"));
+    assertEquals("https://download.gocd.org/binaries/19.2.0-8641/win/go-agent-19.2.0-8641-jre-64bit-setup.exe", DownloadUrls.windowsGoAgent("19.xyz"));
   }
 
   @Test

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/azure/vm/LinuxCustomScriptExtensionTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/azure/vm/LinuxCustomScriptExtensionTest.java
@@ -30,7 +30,7 @@ class LinuxCustomScriptExtensionTest {
 
   @Test
   void shouldCreateAzureCustomExtensionScriptToInstallGoAgent() {
-    String goAgentVersion = "19.4.0";
+    String goAgentVersion = "19.2.0";
     LinuxCustomScriptExtension extension = new LinuxCustomScriptExtension(goAgentVersion,
         "http://go-server/go",
         "auto-register-key",

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/azure/vm/WindowsPlatformConfigStrategyTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/azure/vm/WindowsPlatformConfigStrategyTest.java
@@ -60,23 +60,23 @@ class WindowsPlatformConfigStrategyTest extends BaseTest {
   void shouldAddWindowsOSProperties() {
     PluginSettings pluginSettings = createPluginSettings();
     VmConfig vmConfig = new VmConfig.Builder()
-        .setRequestParams(new CreateAgentRequest("",
-            new ElasticProfile("Size",
-                "",
-                "imageId",
-                "",
-                WINDOWS, "Standard_LRS", "", "50", ""),
-            "",
-            new JobIdentifier()))
-        .setSettingsParams(pluginSettings).build();
+	.setRequestParams(new CreateAgentRequest("",
+	    new ElasticProfile("Size",
+		"",
+		"imageId",
+		"",
+		WINDOWS, "Standard_LRS", "", "50", ""),
+	    "",
+	    new JobIdentifier()))
+	.setSettingsParams(pluginSettings).build();
     VirtualMachine.DefinitionStages.WithOS withOS = Mockito.mock(VirtualMachine.DefinitionStages.WithOS.class, Mockito.RETURNS_DEEP_STUBS);
     VirtualMachine.DefinitionStages.WithCreate mockReturn = mock(VirtualMachine.DefinitionStages.WithCreate.class);
     when(withOS.withWindowsCustomImage("imageId")
-        .withAdminUsername(pluginSettings.getWindowsUserName())
-        .withAdminPassword(pluginSettings.getWindowsPassword())
-        .withOSDiskStorageAccountType(StorageAccountTypes.STANDARD_LRS)
-        .withSize("Size"))
-        .thenReturn(mockReturn);
+	.withAdminUsername(pluginSettings.getWindowsUserName())
+	.withAdminPassword(pluginSettings.getWindowsPassword())
+	.withOSDiskStorageAccountType(StorageAccountTypes.STANDARD_LRS)
+	.withSize("Size"))
+	.thenReturn(mockReturn);
 
     VirtualMachine.DefinitionStages.WithCreate withCreate = windowsPlatformConfigStrategy.addOS(withOS, vmConfig);
 
@@ -173,7 +173,7 @@ class WindowsPlatformConfigStrategyTest extends BaseTest {
       put("agent_id", "agentId");
       put("username", "username");
       put("password", "password");
-      put("go_agent_installer_url", "https://download.gocd.org/binaries/19.4.0-9155/win/go-agent-19.4.0-9155-jre-64bit-setup.exe");
+      put("go_agent_installer_url", "https://download.gocd.org/binaries/19.2.0-8641/win/go-agent-19.2.0-8641-jre-64bit-setup.exe");
     }};
     assertEquals(expectedParams, actualParams);
     verify(mockVirtualMachines).runPowerShellScript("groupName", "vmName", Collections.singletonList("install script"), Collections.emptyList());


### PR DESCRIPTION
After GoCD 19.2.0, elastic agent will use the cluster profile to replace the elastic profile. So we need to switch GoCD version to 19.2.0 to let the plugin work at now.