### PR TITLE
#9 - Use subscription ID instead of default subscription

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ gocdPlugin {
 }
 
 version = gocdPlugin.fullVersion(project)
+sourceCompatibility = 11
+targetCompatibility = 11
 
 // In this section you declare where to find the dependencies of your project
 repositories {

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/azure/client/GoCDAzureClientFactory.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/azure/client/GoCDAzureClientFactory.java
@@ -24,14 +24,18 @@ import com.thoughtworks.gocd.elasticagent.azure.PluginSettings;
 
 import java.io.IOException;
 
-//:TODO Add unit test
 public class GoCDAzureClientFactory {
 
   public GoCDAzureClient initialize(PluginSettings settings) throws IOException {
-    return initialize(settings.getClientId(), settings.getDomain(), settings.getSecret(), settings.getResourceGroup());
+    return initialize(settings.getClientId(), settings.getDomain(), settings.getSecret(), settings.getResourceGroup(), settings.getNetworkId());
   }
 
-  public GoCDAzureClient initialize(String clientId, String domain, String secret, String resourceGroup) throws IOException {
+  public GoCDAzureClient initialize(String clientId, String domain, String secret, String resourceGroup, String networkID) throws IOException {
+    String subscriptionID = networkID.replaceAll("^/subscriptions/([0-9a-f-]+)/.*", "$1");
+    return createClient(clientId, domain, secret, resourceGroup, subscriptionID);
+  }
+
+  protected GoCDAzureClient createClient(String clientId, String domain, String secret, String resourceGroup, String subscriptionID) {
     ApplicationTokenCredentials credentials = new ApplicationTokenCredentials(clientId,
         domain,
         secret,
@@ -40,7 +44,7 @@ public class GoCDAzureClientFactory {
     Azure azure = Azure.configure()
         .withLogLevel(LogLevel.BASIC)
         .authenticate(credentials)
-        .withDefaultSubscription();
+        .withSubscription(subscriptionID);
     return new GoCDAzureClient(azure, resourceGroup, new NetworkDecorator(azure));
   }
 }

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/azure/executors/ValidateConfigurationExecutor.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/azure/executors/ValidateConfigurationExecutor.java
@@ -34,34 +34,36 @@ import static com.thoughtworks.gocd.elasticagent.azure.executors.GetPluginConfig
 
 public class ValidateConfigurationExecutor implements RequestExecutor {
 
-  private final Map<String, String> settings;
-  private final List<Validation> validations;
-  private GoCDAzureClientFactory goCDAzureClientFactory;
+    private final Map<String, String> settings;
+    private final List<Validation> validations;
+    private GoCDAzureClientFactory goCDAzureClientFactory;
 
-  public ValidateConfigurationExecutor(Map<String, String> settings, GoCDAzureClientFactory goCDAzureClientFactory, List<Validation> validations) {
-    this.settings = settings;
-    this.goCDAzureClientFactory = goCDAzureClientFactory;
-    this.validations = validations;
-  }
-
-  public GoPluginApiResponse execute() {
-    ValidationResult validationResult = new ValidationResult();
-    try {
-      GoCDAzureClient client = getGoCDAzureClient(settings);
-      validations.forEach(validation -> validationResult.addErrors(validation.run(settings, client)));
-    } catch (IOException | RuntimeException ex) {
-      LOG.debug("Azure AuthenticationError ", ex);
-      validationResult.addError(CLIENT_ID.key(), AZURE_AUTHENTICATION_ERROR);
-      validationResult.addError(SECRET.key(), AZURE_AUTHENTICATION_ERROR);
-      validationResult.addError(DOMAIN.key(), AZURE_AUTHENTICATION_ERROR);
+    public ValidateConfigurationExecutor(Map<String, String> settings, GoCDAzureClientFactory goCDAzureClientFactory, List<Validation> validations) {
+        this.settings = settings;
+        this.goCDAzureClientFactory = goCDAzureClientFactory;
+        this.validations = validations;
     }
-    return DefaultGoPluginApiResponse.success(validationResult.toJson());
-  }
 
-  private GoCDAzureClient getGoCDAzureClient(Map<String, String> connectionParams) throws IOException {
-    return goCDAzureClientFactory.initialize(connectionParams.get(CLIENT_ID.key()),
-        connectionParams.get(DOMAIN.key()),
-        connectionParams.get(SECRET.key()),
-        connectionParams.get(RESOURCE_GROUP.key()));
-  }
+    public GoPluginApiResponse execute() {
+        ValidationResult validationResult = new ValidationResult();
+        try {
+            GoCDAzureClient client = getGoCDAzureClient(settings);
+            validations.forEach(validation -> validationResult.addErrors(validation.run(settings, client)));
+        } catch (IOException | RuntimeException ex) {
+            LOG.debug("Azure AuthenticationError ", ex);
+            validationResult.addError(CLIENT_ID.key(), AZURE_AUTHENTICATION_ERROR);
+            validationResult.addError(SECRET.key(), AZURE_AUTHENTICATION_ERROR);
+            validationResult.addError(DOMAIN.key(), AZURE_AUTHENTICATION_ERROR);
+        }
+        return DefaultGoPluginApiResponse.success(validationResult.toJson());
+    }
+
+    private GoCDAzureClient getGoCDAzureClient(Map<String, String> connectionParams) throws IOException {
+        return goCDAzureClientFactory.initialize(
+                connectionParams.get(CLIENT_ID.key()),
+                connectionParams.get(DOMAIN.key()),
+                connectionParams.get(SECRET.key()),
+                connectionParams.get(RESOURCE_GROUP.key()),
+                connectionParams.get(NETWORK_ID.key()));
+    }
 }

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/azure/client/GoCDAzureClientFactoryTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/azure/client/GoCDAzureClientFactoryTest.java
@@ -1,0 +1,25 @@
+package com.thoughtworks.gocd.elasticagent.azure.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+class GoCDAzureClientFactoryTest {
+    @Test
+    void shouldGetSubscriptionIDFromNetworkID() throws IOException {
+        verifySubscriptionId("/subscriptions/abcdef98-0123-4567-890a-fedcba01/resourceGroups/", "abcdef98-0123-4567-890a-fedcba01");
+        verifySubscriptionId("/somethingelse", "/somethingelse");
+        verifySubscriptionId("", "");
+    }
+
+    private void verifySubscriptionId(String networkID, String expectedSubscriptionID) throws IOException {
+        GoCDAzureClientFactory factory = spy(GoCDAzureClientFactory.class);
+        when(factory.createClient(anyString(), anyString(), anyString(), anyString(), eq(expectedSubscriptionID))).thenReturn(mock(GoCDAzureClient.class));
+
+        factory.initialize("clientID1", "domainID1", "secret1", "resourceGroup1", networkID);
+
+        verify(factory).createClient(eq("clientID1"), eq("domainID1"), eq("secret1"), eq("resourceGroup1"), eq(expectedSubscriptionID));
+    }
+}

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/azure/executors/ValidateConfigurationExecutorTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/azure/executors/ValidateConfigurationExecutorTest.java
@@ -122,7 +122,7 @@ class ValidateConfigurationExecutorTest {
     Validation validation1 = mock(Validation.class);
     Validation validation2 = mock(Validation.class);
     validateConfigurationExecutor = new ValidateConfigurationExecutor(settings, clientFactory, Arrays.asList(validation1, validation2));
-    when(clientFactory.initialize(any(), any(), any(), any())).thenReturn(mockClient);
+    when(clientFactory.initialize(any(), any(), any(), any(), any())).thenReturn(mockClient);
     when(validation2.run(settings, mockClient)).thenReturn(Collections.singletonMap("key", "error message"));
 
     GoPluginApiResponse response = validateConfigurationExecutor.execute();
@@ -135,7 +135,7 @@ class ValidateConfigurationExecutorTest {
 
   @Test
   void shouldReturnAuthenticationErrorsWhenAzureCredentialsAreInvalid() throws Exception {
-    when(clientFactory.initialize(any(), any(), any(), any())).thenThrow(RuntimeException.class);
+    when(clientFactory.initialize(any(), any(), any(), any(), any())).thenThrow(RuntimeException.class);
     GoPluginApiResponse response = new ValidateConfigurationExecutor(Collections.emptyMap(), clientFactory, Collections.emptyList()).execute();
 
     assertEquals(200, response.responseCode());


### PR DESCRIPTION
- The Azure client was created using the default subscription. However, if the subscription your network ID pointed to was not the default one, there would be errors shown during configuration. See: https://github.com/gocd/azure-elastic-agent-plugin/issues/9

- Changed (fixed) Java version compatibility to 11. 