### PR TITLE
Fixes scripts for Linux agent

### DIFF
--- a/src/main/resources/linux_start_go_agent.template.flth
+++ b/src/main/resources/linux_start_go_agent.template.flth
@@ -1,7 +1,9 @@
+#!/usr/bin/env bash
+
 set -e
 
 agent_dir="/var/lib/go-agent"
-default_jre_dir="/var/lib/jdk/jdk-12"
+default_jre_dir="/var/lib/jdk/jdk-11.0.17"
 
 if [ ! -x "$(command -v java)" ]; then
      export GO_JAVA_HOME=$default_jre_dir

--- a/src/main/resources/linux_start_go_agent.template.flth
+++ b/src/main/resources/linux_start_go_agent.template.flth
@@ -3,7 +3,7 @@
 set -e
 
 agent_dir="/var/lib/go-agent"
-default_jre_dir="/var/lib/jdk/jdk-11.0.17"
+default_jre_dir="/var/lib/jdk/jdk-17.0.5+8-jre"
 
 if [ ! -x "$(command -v java)" ]; then
      export GO_JAVA_HOME=$default_jre_dir

--- a/src/main/resources/post_provision_script.template.ftlh
+++ b/src/main/resources/post_provision_script.template.ftlh
@@ -2,17 +2,17 @@
 
 set -e
 
-java_download_url="https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_linux-x64_bin.tar.gz"
+java_download_url="https://download.bell-sw.com/java/11.0.17+7/bellsoft-jdk11.0.17+7-linux-amd64.tar.gz"
 
 reset_dir () {
    rm -rf $1
-   mkdir $1
+   mkdir -p $1
 }
 
 install_java () {
       wget $java_download_url
       reset_dir /var/lib/jdk
-      tar -xvf openjdk-13.0.2_linux-x64_bin.tar.gz -C /var/lib/jdk/
+      tar -xvf bellsoft-jdk11.0.17+7-linux-amd64.tar.gz -C /var/lib/jdk/
 }
 
 echo "Setting up unzip utility"

--- a/src/main/resources/post_provision_script.template.ftlh
+++ b/src/main/resources/post_provision_script.template.ftlh
@@ -2,7 +2,7 @@
 
 set -e
 
-java_download_url="https://download.bell-sw.com/java/11.0.17+7/bellsoft-jdk11.0.17+7-linux-amd64.tar.gz"
+java_download_url="https://api.adoptium.net/v3/binary/version/jdk-17.0.5%2B8/linux/x64/jre/hotspot/normal/eclipse?project=jdk"
 
 reset_dir () {
    rm -rf $1
@@ -10,9 +10,9 @@ reset_dir () {
 }
 
 install_java () {
-      wget $java_download_url
+      wget $java_download_url --output-document=jre17.tar.gz 
       reset_dir /var/lib/jdk
-      tar -xvf bellsoft-jdk11.0.17+7-linux-amd64.tar.gz -C /var/lib/jdk/
+      tar -xvf jre17.tar.gz -C /var/lib/jdk/
 }
 
 echo "Setting up unzip utility"


### PR DESCRIPTION
**Changes**:
- Download and install latest JDK 11
- Start agent with installed JDK 11
- Fixes #23 